### PR TITLE
Scale controller and disable text selection

### DIFF
--- a/style.css
+++ b/style.css
@@ -389,12 +389,16 @@ body {
     background: linear-gradient(45deg, var(--primary-color), var(--secondary-color));
     border: none;
     border-radius: 8px;
-    padding: 10px 15px;
+    padding: 13px 20px;
     color: white;
     font-weight: bold;
     cursor: pointer;
     transition: all 0.3s ease;
-    font-size: 0.9em;
+    font-size: 1.17em;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: manipulation;
 }
 
 .control-btn:hover {
@@ -411,9 +415,9 @@ body {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(3, 1fr);
-    gap: 5px;
-    width: 120px;
-    height: 120px;
+    gap: 6.5px;
+    width: 156px;
+    height: 156px;
 }
 
 .move-btn {
@@ -421,12 +425,16 @@ body {
     border: none;
     border-radius: 6px;
     color: white;
-    font-size: 1.2em;
+    font-size: 1.56em;
     cursor: pointer;
     transition: all 0.2s ease;
     display: flex;
     align-items: center;
     justify-content: center;
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+    touch-action: manipulation;
 }
 
 .move-btn:hover {
@@ -436,7 +444,7 @@ body {
 
 .move-btn.center {
     background: linear-gradient(45deg, var(--warning-color), #e17055);
-    font-size: 1.5em;
+    font-size: 1.95em;
 }
 
 /* メニュー画面 */


### PR DESCRIPTION
## Summary
- enlarge on-screen control buttons and directional pad by 130%
- disable text selection and long-press callouts on game buttons for clearer tapping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e7087be58833089d0933fc8a5f480